### PR TITLE
parameterise rebase-filter-maint

### DIFF
--- a/git/rebase-filter-maint
+++ b/git/rebase-filter-maint
@@ -5,9 +5,7 @@
 # package maintainer(s) (or not)
 
 # Usage:
-# - git checkout -b filtered
-# - git reset --hard ${base}
-# - bash ~/scripts/rebase-filter
+# Run this script from the branch that you need to filter.
 
 # Configuration:
 # - maintainers: regex of maintainers to filter for/out
@@ -19,17 +17,54 @@
 # - continue_on_error: give a list of commits which need rebasing at the end
 # - debug: noisy or not?
 
-maintainers="(some-project-to-treat-specially)"
+# Retain these values as defaults
 mode="blacklist"
 base="origin/master"
-minefield="misc"
+minefield=$(git rev-parse --abbrev-ref HEAD)
 create_branches=1
 create_branches_inverse=0
 continue_on_error=0
 sorted=1
-debug=1
+debug=0
 
-#
+usage() {
+	echo "Usage: rebase-filter-maint [ -b | --blacklist] [ -c | --create-branches ] [ -d | --debug ] [ -m | --maintainers python@ ] --minefield branch-to-filter [ -s | --source-branch origin/master ] [ -w | --whitelist ]"
+	exit 2
+}
+
+parsed_args=$(getopt -a -n rebase-filter-maint -o bcdm:s:w --long blacklist,create-branches,debug,maintainers:,minefield:,source-branch:,whitelist -- "$@")
+eval set -- "$parsed_args"
+while :
+do
+	case "$1" in
+		-b | --blacklist ) mode="blacklist" ; shift ;;
+		-c | --create-branches ) create_branches=1 ; shift ;;
+		-d | --debug ) debug=1; shift ;;
+		-m | --maintainers ) maintainers="$2" ; shift 2 ;;
+		--minefield ) minefield="$2" ; shift 2 ;;
+		-s | --source-branch ) base="$2" ; shift 2 ;;
+		-w | --whitelist ) mode="whitelist" ; shift ;;
+		-- ) shift ; break ;;
+		*)  echo "Unexpected option: $1"
+		    usage ;;
+	esac
+done
+
+if [[ -z ${maintainers// } ]]; then
+	echo "Either set the 'maintainers' envvar or specify --maintainers."
+	exit 1
+elif [[ $debug -eq 1 ]]; then
+	echo "Maintainers Regex set to '${maintainers}'"
+fi
+
+# Ensure that $base is clean
+git reset --hard $base
+
+# Make sure that we're not somewhere deep within the repo to simplify the rest of the script
+# Doesn't hurt anything if we're already there.
+cd $(git rev-parse --show-toplevel)
+
+# Initialise a few variables
 skipped_commits=()
 error_commits_whitelist=()
 error_commits_blacklist=()


### PR DESCRIPTION
This commit parameterises the rebase-filter-maint script to make it more user friendly.

Minimal changes were made to the preset envvars:

- `maintainers` was removed - set it as an envvar when calling the script or use e.g. `--maintainers python@`
- `minefield` is now set to the current git branch by default (though this can be overwriten using `--minefield`
- `debug` is no longer a default option (we can easily call it when we want it now)

I've gotta actually get on with getting these ebuilds merged, but it shouldn't be too hard from here to make life easier by setting some default values (so that envvars that we pass in aren't overwritten by what's in the file) and some additional params.

No changes to logic aside from the removed preset envvars.

All seems to work - I've got a neat pile of filtered commits to start QAing and testing now...