### PR TITLE
improvement to bump-go and bump-rust scripts

### DIFF
--- a/maint/bump-go
+++ b/maint/bump-go
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # TODO: could add guessed subdir into S in ebuild?
-# TODO: handle licensing via e.g. dev-go/lichen
 # TODO: handle where a vendor dir already exists
 . /lib/gentoo/functions.sh || { echo "Could not find gentoo-functions' functions.sh!" ; exit 1; }
 . "$(pkg-config iwdevtools --variable=atomf)" || { eerror "Could not find iwdevtools' atomf library! Emerge app-portage/iwdevtools?" ; exit 1; }
@@ -180,6 +179,39 @@ ebegin "Creating tarball"
 	LC_ALL=C TZ=UTC ${tar} ${REPRODUCIBLE_TAR_ARGS} -acf ${P}-deps.tar.xz ${tar_target} || exit 1
 
 	mv ${P}-deps.tar.xz $(portageq distdir)/ || exit 1
+)
+eend $? || exit 1
+
+# 4. collect licenses
+ebegin "Collecting licenses"
+(
+	cd "${S}" || exit 1
+	export GOCACHE="${PORTAGE_TMPDIR}/go-cache"
+	export GOMODCACHE="${PORTAGE_TMPDIR}/go-mod"
+	readarray -t LICENSES < <(go-licenses report ./... | cut -d',' -f3 | sort -u)
+
+	MAPPING_FILE=$(portageq get_repo_path / gentoo)/metadata/license-mapping.conf
+
+	readarray -t GENTOO_LICENSES < <(
+		for license in "${LICENSES[@]}"; do
+			VAL=$(grep -Po "^${license} = \K.*" "${MAPPING_FILE}")
+			if [[ -n ${VAL} ]]; then
+				echo "${VAL}"
+			else
+				ewarn "Unknown license: ${license}"
+				echo "${license}"
+			fi
+		done | sort -u
+	)
+
+	ebuild=${ORIGINAL_PWD}/${CATEGORY}/${PN}/${ebuild}
+
+	if grep -q "# Dependent licenses" ${ORIGINAL_PWD}/${ebuild} ; then
+		# TODO: we need to sed the previous block with the new one. I've failed to build a sed expression for that
+		sed -i -e "/LICENSE=/ a# Dependent licenses\nLICENSE+=\" $(printf " %s" "${GENTOO_LICENSES[@]}")\"" ${ebuild} || exit 1
+	else
+		sed -i -e "/LICENSE=/ a# Dependent licenses\nLICENSE+=\" $(printf " %s" "${GENTOO_LICENSES[@]}")\"" ${ebuild} || exit 1
+	fi
 )
 eend $? || exit 1
 

--- a/maint/bump-rust
+++ b/maint/bump-rust
@@ -48,6 +48,12 @@ sed -i -e '/^EAPI=.*/a\\nCRATES=" "' ${ebuild} || exit 1
 einfo "Sedding out 'crates' tarball line if exists"
 sed -i -E "/^(\t+)?SRC_URI.*crates/ s/^/#/" ${ebuild} || exit 1
 
+if grep -q -Fe 'https://github.com/gentoo-crate-dist' ${ebuild}; then
+	ewarn "Detected usage of gentoo-crate-dist, won't create crates tarball"
+	EXISTING_CRATES_TARBALL=1
+	PYCARGOEBUILD_EXTRA_ARGS=( --no-write-crate-tarball )
+fi
+
 # 3. Fetch!
 einfo "Fetching ${P}"
 ebuild ${ebuild} manifest || exit 1
@@ -65,7 +71,7 @@ ebuild ${ebuild} clean unpack || exit 1
 export S=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${PORTAGE_TMPDIR}"/portage/${CATEGORY}/${PF}/temp/environment)
 
 ebegin "Running 'pycargoebuild -i ${ebuild} -c ${S}'"
-pycargoebuild -i ${ebuild} -c ${S} || exit 1
+pycargoebuild -i ${ebuild} -c ${S} "${PYCARGOEBUILD_EXTRA_ARGS[@]}" || exit 1
 eend $? || exit 1
 
 # 5. Undo the sed we did earlier to the ebuild
@@ -77,6 +83,8 @@ einfo "Generating manifest"
 ebuild ${ebuild} clean manifest || exit 1
 
 einfo "All done."
-einfo "Dep tarball now at: $(portageq distdir)/${P}-deps.tar.xz!"
 
-rsync --mkpath -av -P "$(portageq distdir)/${P}-crates.tar.xz" dev.gentoo.org:~/public_html/distfiles/${CATEGORY}/${PN}/${P}-crates.tar.xz
+if [[ -z ${EXISTING_CRATES_TARBALL} ]]; then
+	einfo "Dep tarball now at: $(portageq distdir)/${P}-deps.tar.xz!"
+	rsync --mkpath -av -P "$(portageq distdir)/${P}-crates.tar.xz" dev.gentoo.org:~/public_html/distfiles/${CATEGORY}/${PN}/${P}-crates.tar.xz
+fi

--- a/maint/bump-rust
+++ b/maint/bump-rust
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # TODO: could add guessed subdir into S in ebuild?
-# TODO: handle licensing
 . /lib/gentoo/functions.sh || { echo "Could not find gentoo-functions' functions.sh!" ; exit 1; }
 . "$(pkg-config iwdevtools --variable=atomf)" || { eerror "Could not find iwdevtools' atomf library! Emerge app-portage/iwdevtools?" ; exit 1; }
 
@@ -11,8 +10,6 @@ else
 fi
 
 ORIGINAL_PWD=$(pwd)
-
-ewarn "DEPRECATION NOTICE: Please use app-portage/pycargoebuild instead if it works for your case!"
 
 ${SCRIPT_DIR}/bump-generic "$@" || {
 	case $? in
@@ -47,11 +44,15 @@ fi
 # (Can try ${P} if this fails for some reason)
 sed -i -e '/^EAPI=.*/a\\nCRATES=" "' ${ebuild} || exit 1
 
-# 2. Fetch!
+# 2. sed out the dep tarball line if there is one, so we can fetch.
+einfo "Sedding out 'crates' tarball line if exists"
+sed -i -E "/^(\t+)?SRC_URI.*crates/ s/^/#/" ${ebuild} || exit 1
+
+# 3. Fetch!
 einfo "Fetching ${P}"
 ebuild ${ebuild} manifest || exit 1
 
-# 3. Unpack then fetch Rust deps
+# 4. Unpack then fetch Rust deps
 einfo "Unpacking ${P}"
 
 # (We want to own this place)
@@ -60,60 +61,22 @@ export PORTAGE_USERNAME="$(whoami)"
 export PORTAGE_WORKDIR_MODE="775"
 ebuild ${ebuild} clean unpack || exit 1
 
-# We need to export these for use in the subshells :(
-export D="${PORTAGE_TMPDIR}"/portage/${CATEGORY}/${PF}/image
-export WORKDIR="${PORTAGE_TMPDIR}"/portage/${CATEGORY}/${PF}/work
 # Borrowed from mgorny-dev-tools' pkgdiff
 export S=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${PORTAGE_TMPDIR}"/portage/${CATEGORY}/${PF}/temp/environment)
 
-cmd="CARGO_HOME=${WORKDIR}/distdir/cargo-tmp cargo fetch"
-ebegin "Running '${cmd}'"
-(
-	cd "${S}" || exit 1
-
-	if [[ ! -f Cargo.toml ]] ; then
-		ewarn "No Cargo.toml in $(pwd)!"
-		ewarn "Guessing first top-three-level subdir with Cargo.toml?"
-		dirs=$(find . -maxdepth 3 -type d -print)
-
-		for dir in ${dirs[@]} ; do
-			if [[ -f ${dir}/Cargo.toml ]] ; then
-				einfo "Entering ${dir} which contains a Cargo.toml file"
-				cd ${dir} || exit 1
-			fi
-		done || { eerror "Could not find any Cargo.toml in top-three-level subdirs either!" ; exit 1; }
-	fi
-
-	eval "${cmd}" || exit 1
-)
+ebegin "Running 'pycargoebuild -i ${ebuild} -c ${S}'"
+pycargoebuild -i ${ebuild} -c ${S} || exit 1
 eend $? || exit 1
 
-ebegin "Creating CRATES variable"
-(
-	cd "${S}" || exit 1
-
-	# TODO: nullglob?
-	crates=$(ls -1 "${WORKDIR}"/distdir/cargo-tmp/registry/src/*)
-	test $? -gt 0 && exit 1
-
-	echo ${crates} > "${WORKDIR}"/crates-list
-)
-eend $? || exit 1
-
-# Add CRATES back
+# 5. Undo the sed we did earlier to the ebuild
 cd ${ORIGINAL_PWD}/${CATEGORY}/${PN} || exit 1
-einfo "Adding CRATES to ebuild"
-
-# Drop the dummy line we added
-sed -i -e '/CRATES=/d' ${ebuild} || exit 1
-
-crates=$(<"${WORKDIR}"/crates-list)
-# Get a new line at the end
-crates+="\n"
-# Dump our new CRATES into the ebuild
-sed -i -e "/^EAPI=.*/a\\\nCRATES=\"\n$(printf '\\\t%s\\\n' ${crates[@]})\"" ${ebuild} || exit 1
+einfo "Unsedding deps line in ebuild"
+sed -i -e "/^#SRC_URI.*crates/ s/^#//" ${ebuild} || exit 1
 
 einfo "Generating manifest"
 ebuild ${ebuild} clean manifest || exit 1
 
 einfo "All done."
+einfo "Dep tarball now at: $(portageq distdir)/${P}-deps.tar.xz!"
+
+rsync --mkpath -av -P "$(portageq distdir)/${P}-crates.tar.xz" dev.gentoo.org:~/public_html/distfiles/${CATEGORY}/${PN}/${P}-crates.tar.xz


### PR DESCRIPTION
Some improvements I did for both scripts. I also improved my local invoke by using those bash functions, so I only need to pass ${PV}

```shell
bump-go() (
    pkg=$(pkg)
    cd ~/src/gentoo
    ACCEPT_KEYWORDS="~amd64" ~/src/sam-gentoo-scripts/maint/bump-go ${pkg} ${1:?missing version}
)

bump-rust() (
    pkg=$(pkg)
    cd ~/src/gentoo
    ACCEPT_KEYWORDS="~amd64" ~/src/sam-gentoo-scripts/maint/bump-rust ${pkg} ${1:?missing version}
)
```