### PR TITLE
sync: repo-patches: exit cleanly if repo patch dir does not exist

### DIFF
--- a/sync/repo.postsync.d/01-repo-patches
+++ b/sync/repo.postsync.d/01-repo-patches
@@ -12,6 +12,8 @@ repository_path=${3}
 patched_any=0
 ret=0
 
+[[ ! -d "${repository_name}" ]] && exit
+
 readarray -d '' -t patches < <(
 	LC_COLLATE=C find \
 		"/etc/portage/repo-patches/${repository_name}" \


### PR DESCRIPTION
If the repo patch directory does not exist, we can safely assume there is no work to be done. This avoids an unpleasent, and not necessarily useful, error message from find:

> find: ‘/etc/portage/repo-patches/<repo>’: No such file or directory

Whilst we could indeed simply set find's stderr to /dev/null, that has the unfortunate side effect of removing _all_ possible error messages that find may emit, which is not ideal as that would make debugging any issues unrelated to the repo patch directory's existence a pain. For example, some kind of permission error.

Hence, it is preferable to just exit early such that we keep any error messages from find.