### PR TITLE
maint/bump-go: Don't process go.mod files in a path containing /testdata/

### DIFF
--- a/maint/bump-go
+++ b/maint/bump-go
@@ -113,6 +113,11 @@ ebegin "Running '${cmd}'"
 				continue
 			fi
 
+			# Skip testdata (may have deliberately bad go.mod files)
+			if [[ ${dir} =~ /testdata(/|$) ]]; then
+				continue
+			fi
+
 			if [[ -f ${dir}/go.mod ]] ; then
 				einfo "Entering ${dir} which contains a go.mod file"
 				cd ${dir} || exit 1


### PR DESCRIPTION
Have been using this locally for a few years, after encountering intentionally broken go.mod files in Trivy's test suite.